### PR TITLE
Upgraded psutil (CVE-2019-18874)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorama == 0.4.4
 pyinstaller
-psutil == 2.1.1
+psutil == 5.9.8
 pyfiglet == 0.7


### PR DESCRIPTION
Upgraded psutil library to 5.9.8 to prevent double free vulnerability (CVE-2019-18874).